### PR TITLE
Made parsing arguments easier by using docopt.net

### DIFF
--- a/Chirp.CLI/Chirp.CLI.csproj
+++ b/Chirp.CLI/Chirp.CLI.csproj
@@ -7,5 +7,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="docopt.net" Version="0.8.1" />
+  </ItemGroup>
+
 
 </Project>

--- a/Chirp.CLI/Program.cs
+++ b/Chirp.CLI/Program.cs
@@ -3,11 +3,38 @@ using System.Data.Common;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Chirp.CLI;
+using DocoptNet;
+// See https://aka.ms/new-console-template for more information
+using System.Data.Common;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using DocoptNet;
 
-if(args.Length == 0)
-    return;
-if(args[0].ToLower() == "read")
-{
+//chirp --version in usage useless? still works when removed
+const string usage = @"Chirp.
+
+Usage:
+    chirp read
+    chirp cheep <message>
+    chirp (-h | --help)
+    chirp --version
+
+Options:
+    -h --help   Show this screen.
+    --version   Show version.
+";
+
+var arguments = new Docopt().Apply(usage, args, version: "Chirp 1.0", exit: true)!;
+if (arguments["read"].IsTrue){
+    ReadCheeps();
+}
+if (arguments["cheep"].IsTrue){
+    WriteCheep(arguments["<message>"].ToString());
+}
+/// <summary>
+    /// Writes all cheep messages in the csv file to the console
+    /// </summary>
+static void ReadCheeps(){
     var sr = new StreamReader("data/chirp_cli_db.csv");
     
     sr.ReadLine();
@@ -17,19 +44,15 @@ if(args[0].ToLower() == "read")
         Cheep chirp = new Cheep(sr.ReadLine());
         cheeps.Add(chirp);
     }
-    UserInterface.Writechirp(cheeps);
+    UserInterface.WriteChirp(cheeps);
 }
-
-
-if (args[0].ToLower() == "cheep") 
-{
-    if (args[1] == null)
-    {
-        Console.WriteLine("Text cannot be emtpy!");
-        return;
-    }
+/// <summary>
+    /// Takes a string message, constructs a Cheep object, and writes it to the csv file
+    /// </summary>
+    /// <param name="argText">The message sent as a cheep, to be written to the csv file</param>
+static void WriteCheep(string argText){
     string userName = Environment.UserName;
-    string text = args[1];
+    string text = argText;
     DateTimeOffset timestamp = DateTime.Now;
     Cheep chirp = new Cheep(timestamp, userName, text);
     chirp.WriteToCSV();

--- a/Chirp.CLI/UserInterface.cs
+++ b/Chirp.CLI/UserInterface.cs
@@ -6,9 +6,11 @@ public class UserInterface
     /// Takes a cheep and writes its to string in the console 
     /// </summary>
     /// <param name="ch">The given cheep that will be written in the console</param>
-    public static void Writechirp(IEnumerable<Cheep> ch)
+    public static void WriteChirp(IEnumerable<Cheep> ch)
     {
-        Console.WriteLine(ch.ToString());
+        foreach (Cheep value in ch){
+           Console.WriteLine(value.ToString());
+        }
     }
     
 }


### PR DESCRIPTION
Implemented docopt to parse "read" and "cheep" console arguments explicitly. "--version" also works through docopt automatically. Made methods for "read" and "cheep" as this was necessary.