### PR TITLE
bug in linux regarding case sensitive paths

### DIFF
--- a/src/Chirp.CLI/Chirp.CLI.csproj
+++ b/src/Chirp.CLI/Chirp.CLI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\simpledb\SimpleDB.csproj" />
+    <ProjectReference Include="..\SimpleDB\SimpleDB.csproj" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Linux could not find file when path was not written in correct case