### PR TITLE
Cheeps can now be deleted by their user, by clicking a link on the cheep you want to delete

### DIFF
--- a/src/Chirp.Core/CheepViewModel.cs
+++ b/src/Chirp.Core/CheepViewModel.cs
@@ -1,2 +1,2 @@
 namespace Chirp.Core; 
-public record CheepViewModel(string Author, string Message, DateTime TimeStamp);
+public record CheepViewModel(string Author, string Message, DateTime TimeStamp, int CheepId);

--- a/src/Chirp.Infrastructure/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/CheepRepository.cs
@@ -17,7 +17,7 @@ public interface ICheepRepository
 
     Task<int> GetCheepPageAmountFollowed(string authorName);
 
-    Task<IEnumerable<CheepViewModel>> GetCheepsByAuthor(string authorName);
+    Task<IEnumerable<int>> GetCheepIDsByAuthor(string authorName);
     Task CreateCheep(string authorName, string text, DateTime timestamp);
     Task RemoveCheep(int cheepId);
 }
@@ -194,11 +194,11 @@ public class CheepRepository : ICheepRepository
 
     
     /// <summary>
-    /// Returns a list of Cheeps written by the specified Author..
+    /// Returns a list of cheep IDs from the cheeps written by the specified Author..
     /// </summary>
     /// <param name="authorName">The name of the Author</param>
-    /// <returns>A IEnumerable of Cheeps</returns>
-    public async Task<IEnumerable<CheepViewModel>> GetCheepsByAuthor(string authorName)
+    /// <returns>A IEnumerable of integers</returns>
+    public async Task<IEnumerable<int>> GetCheepIDsByAuthor(string authorName)
     {
         if (authorName is null)
             throw new ArgumentNullException(nameof(authorName));
@@ -207,9 +207,9 @@ public class CheepRepository : ICheepRepository
         if (author is null)
             throw new ArgumentException($"Author with name '{authorName}' not found.");
         
-        List<CheepViewModel> cheepList = await dbContext.Cheeps
+        List<int> cheepList = await dbContext.Cheeps
             .Where(c => c.AuthorId == author.AuthorId)
-            .Select(c => new CheepViewModel(author.Name, c.Text, c.TimeStamp, c.CheepId))
+            .Select(c => c.CheepId)
             .ToListAsync();
         return cheepList;
     }

--- a/src/Chirp.Infrastructure/CheepRepository.cs
+++ b/src/Chirp.Infrastructure/CheepRepository.cs
@@ -16,6 +16,8 @@ public interface ICheepRepository
     Task<int> GetCheepPageAmountAuthor(string authorName);
 
     Task<int> GetCheepPageAmountFollowed(string authorName);
+
+    Task<IEnumerable<CheepViewModel>> GetCheepsByAuthor(string authorName);
     Task CreateCheep(string authorName, string text, DateTime timestamp);
     Task RemoveCheep(int cheepId);
 }
@@ -61,7 +63,7 @@ public class CheepRepository : ICheepRepository
             .OrderByDescending(c => c.TimeStamp)
             .Skip(skipCount)
             .Take(PageSize)
-            .Select(c => new CheepViewModel(author.Name, c.Text, c.TimeStamp))
+            .Select(c => new CheepViewModel(author.Name, c.Text, c.TimeStamp, c.CheepId))
             .ToListAsync();
         return cheepList;
     }
@@ -95,7 +97,7 @@ public class CheepRepository : ICheepRepository
             .OrderByDescending(c => c.TimeStamp)
             .Skip(skipCount)
             .Take(PageSize)
-            .Select(c => new CheepViewModel(c.Author.Name, c.Text, c.TimeStamp))
+            .Select(c => new CheepViewModel(c.Author.Name, c.Text, c.TimeStamp, c.CheepId))
             .ToListAsync();
         
         return cheepList; 
@@ -118,7 +120,7 @@ public class CheepRepository : ICheepRepository
             .OrderByDescending(c => c.TimeStamp)
             .Skip(skipCount)
             .Take(PageSize)
-            .Select(c => new CheepViewModel(c.Author.Name, c.Text, c.TimeStamp))
+            .Select(c => new CheepViewModel(c.Author.Name, c.Text, c.TimeStamp, c.CheepId))
             .ToListAsync();
 
         return cheepList;
@@ -189,6 +191,29 @@ public class CheepRepository : ICheepRepository
         return totalPages;
         
     }
+
+    
+    /// <summary>
+    /// Returns a list of Cheeps written by the specified Author..
+    /// </summary>
+    /// <param name="authorName">The name of the Author</param>
+    /// <returns>A IEnumerable of Cheeps</returns>
+    public async Task<IEnumerable<CheepViewModel>> GetCheepsByAuthor(string authorName)
+    {
+        if (authorName is null)
+            throw new ArgumentNullException(nameof(authorName));
+
+        Author? author = await dbContext.Authors.SingleOrDefaultAsync(a => a.Name == authorName);
+        if (author is null)
+            throw new ArgumentException($"Author with name '{authorName}' not found.");
+        
+        List<CheepViewModel> cheepList = await dbContext.Cheeps
+            .Where(c => c.AuthorId == author.AuthorId)
+            .Select(c => new CheepViewModel(author.Name, c.Text, c.TimeStamp, c.CheepId))
+            .ToListAsync();
+        return cheepList;
+    }
+
 
     /// <summary>
     /// Adds a new Cheep to the database.

--- a/src/Chirp.Web/Pages/DeletePage.cshtml
+++ b/src/Chirp.Web/Pages/DeletePage.cshtml
@@ -1,0 +1,11 @@
+@page "/delete/{CheepId}"
+@using Chirp.Core
+@model Chirp.Web.Pages.DeleteModel
+@{
+    ViewData["Title"] = "Chirp!";
+    Layout = "Shared/_Layout";
+}
+
+<div>
+    Something went wrong, please go back.
+</div>

--- a/src/Chirp.Web/Pages/DeletePage.cshtml.cs
+++ b/src/Chirp.Web/Pages/DeletePage.cshtml.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using Chirp.Core;
+using Chirp.Infrastructure;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Primitives;
+
+namespace Chirp.Web.Pages;
+
+public class DeleteModel : PageModel
+{
+    private readonly IFollowRepository followRepository;
+
+    private readonly ICheepRepository cheepRepository;
+
+    public List<CheepViewModel> Cheeps { get; set; }
+
+    public DeleteModel(ICheepRepository cheepRepository, IAuthorRepository authorRepository, IFollowRepository followRepository)
+    {
+        this.followRepository = followRepository;
+        this.cheepRepository = cheepRepository;
+    }
+
+    public async Task<IActionResult> OnGetAsync(int CheepId)
+    {
+        if (User.Identity?.IsAuthenticated == true){
+            IEnumerable<CheepViewModel> cheeps = await cheepRepository.GetCheepsByAuthor(User.Identity.Name);
+            foreach (CheepViewModel cheep in cheeps){
+                if (cheep.CheepId == CheepId){
+                    await cheepRepository.RemoveCheep(CheepId);
+                }
+            }
+        }
+        return RedirectToPage("/");
+    }
+}

--- a/src/Chirp.Web/Pages/DeletePage.cshtml.cs
+++ b/src/Chirp.Web/Pages/DeletePage.cshtml.cs
@@ -24,9 +24,9 @@ public class DeleteModel : PageModel
     public async Task<IActionResult> OnGetAsync(int CheepId)
     {
         if (User.Identity?.IsAuthenticated == true){
-            IEnumerable<CheepViewModel> cheeps = await cheepRepository.GetCheepsByAuthor(User.Identity.Name);
-            foreach (CheepViewModel cheep in cheeps){
-                if (cheep.CheepId == CheepId){
+            IEnumerable<int> ids = await cheepRepository.GetCheepIDsByAuthor(User.Identity.Name);
+            foreach (int id in ids){
+                if (id == CheepId){
                     await cheepRepository.RemoveCheep(CheepId);
                 }
             }

--- a/src/Chirp.Web/Pages/PublicTimeline.cshtml
+++ b/src/Chirp.Web/Pages/PublicTimeline.cshtml
@@ -42,6 +42,10 @@
                                 <a href="/follow/@cheep.Author"> follow</a>
                             }
                         }
+                        else if (User.Identity?.IsAuthenticated == true && cheep.Author == User.Identity?.Name){
+                            <a href="/delete/@cheep.CheepId"> delete</a>
+                        }
+                        <!--as the first check is the same as above, the two could be combined into one. less code duplication, but deeper--> 
                         @cheep.Message
                         <small>&mdash; @cheep.TimeStamp</small>
                     </p>

--- a/src/Chirp.Web/Pages/PublicTimeline.cshtml
+++ b/src/Chirp.Web/Pages/PublicTimeline.cshtml
@@ -33,22 +33,23 @@
                         <strong>
                             <a href="/@cheep.Author">@cheep.Author</a>
                         </strong>
-                        <!--==true is required, since it is a bool? noot a bool--> 
-                        @if (User.Identity?.IsAuthenticated == true && cheep.Author != User.Identity?.Name){
-                            @if (await Model.CheckFollow(cheep.Author)){
-                                <a href="/follow/@cheep.Author"> unfollow</a>
+                        <!--==true is required, since it is a bool? not a bool--> 
+                        @if (User.Identity?.IsAuthenticated == true){
+                            if (cheep.Author == User.Identity?.Name){
+                                <a href="/delete/@cheep.CheepId"> delete</a>
                             }
                             else {
+                                @if (await Model.CheckFollow(cheep.Author)){
+                                <a href="/follow/@cheep.Author"> unfollow</a>
+                            }
+                                else {
                                 <a href="/follow/@cheep.Author"> follow</a>
+                                }
                             }
                         }
-                        else if (User.Identity?.IsAuthenticated == true && cheep.Author == User.Identity?.Name){
-                            <a href="/delete/@cheep.CheepId"> delete</a>
-                        }
-                        <!--as the first check is the same as above, the two could be combined into one. less code duplication, but deeper--> 
                         @cheep.Message
                         <small>&mdash; @cheep.TimeStamp</small>
-                    </p>
+                    </p> 
                 </li>
             }
         </ul>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -36,12 +36,18 @@
                         <strong>
                             <a href="/@cheep.Author">@cheep.Author</a>
                         </strong>
-                        @if (User.Identity?.IsAuthenticated == true && cheep.Author != User.Identity?.Name){
-                            @if (await Model.CheckFollow(cheep.Author)){
-                                <a href="/follow/@cheep.Author"> unfollow</a>
+                        <!--==true is required, since it is a bool? not a bool--> 
+                        @if (User.Identity?.IsAuthenticated == true){
+                            if (cheep.Author == User.Identity?.Name){
+                                <a href="/delete/@cheep.CheepId"> delete</a>
                             }
                             else {
+                                @if (await Model.CheckFollow(cheep.Author)){
+                                <a href="/follow/@cheep.Author"> unfollow</a>
+                            }
+                                else {
                                 <a href="/follow/@cheep.Author"> follow</a>
+                                }
                             }
                         }
                         @cheep.Message


### PR DESCRIPTION
IMPORTANT: this implementation of cheep deletion relies on cheepID being included in the cheep DTO, which is not ideal. This is required in order to delete the correct cheep through the method in the repository. An alternate implementation would be to compare a combination of author name, timestamp and text to find the correct cheep to delete, to avoid using the id.